### PR TITLE
feat: add frontend build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm run build:frontend
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest
+      - run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,20 @@ FROM python:3.11-slim
 # Working directory in the container
 WORKDIR /app
 
-# Copy the Python server, migration scripts and front‑end assets. The
-# SQLite database will be created at runtime.
-COPY server.py ./
+# Install Node.js to build the front-end bundle
+RUN apt-get update && apt-get install -y nodejs npm && rm -rf /var/lib/apt/lists/*
+
+# Copy front-end sources and build them
+COPY package.json package-lock.json* ./
+COPY node_modules ./node_modules
+COPY vite.config.js postcss.config.js tailwind.config.js frontend.jsx ./
+COPY src ./src
 COPY public ./public
+RUN npm run build:frontend
+
+# Copy the Python server and migration scripts. The SQLite database will
+# be created at runtime.
+COPY server.py ./
 COPY scripts ./scripts
 
 # Create a volume for persistent database storage

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ minimaliste via une API REST.
 
 - [Guide utilisateur](docs/guide_utilisateur.md)
 
+## Construction du frontend
+
+Le bundle JavaScript est généré avec Vite. Avant de démarrer le serveur
+Python, exécuter :
+
+```bash
+npm run build:frontend
+```
+
+Le Dockerfile et la CI lancent automatiquement cette commande lors du
+déploiement.
+
 ## Déploiement avec Docker
 
 ### Générer des certificats SSL

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:css": "tailwindcss -i ./src/tailwind.css -o ./public/tailwind.css --minify",
     "dev": "vite",
-    "build": "vite build"
+    "build:frontend": "vite build",
+    "build": "npm run build:frontend"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `build:frontend` npm script for Vite bundling
- invoke frontend build in Docker image and CI workflow
- document frontend build procedure in README

## Testing
- `npm run build:frontend` *(fails: sh: 1: vite: not found)*
- `npm install` *(fails: 403 Forbidden fetching @vitejs/plugin-react)*
- `pip install playwright` *(fails: No matching distribution found for playwright)*
- `pytest --ignore=tests/test_ui_account_deletion.py --ignore=tests/test_ui_delete_account_button_visible.py --ignore=tests/test_ui_group_rename.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab7f6640408327b221ba6b468100e8