### PR TITLE
Enable SQLite foreign keys and add regression test

### DIFF
--- a/scripts/migrate_performance_location.py
+++ b/scripts/migrate_performance_location.py
@@ -8,6 +8,7 @@ def migrate() -> bool:
     """Ensure the performances table has a location column.
     Returns True if a migration was performed."""
     conn = sqlite3.connect(DB_PATH)
+    conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
     cur.execute("PRAGMA table_info(performances)")
     columns = [row[1] for row in cur.fetchall()]

--- a/scripts/migrate_suggestion_votes.py
+++ b/scripts/migrate_suggestion_votes.py
@@ -6,6 +6,7 @@ DB_PATH = os.path.join(os.path.dirname(__file__), '..', 'bandtrack.db')
 
 def migrate() -> bool:
     conn = sqlite3.connect(DB_PATH)
+    conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
     # Ensure suggestion_votes table exists
     cur.execute(

--- a/scripts/migrate_to_multigroup.py
+++ b/scripts/migrate_to_multigroup.py
@@ -11,6 +11,7 @@ def generate_code() -> str:
 
 def migrate() -> bool:
     conn = sqlite3.connect(DB_PATH)
+    conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
     # If the core "users" table does not exist yet we are dealing with a
     # fresh database created by ``init_db`` and there is nothing to migrate.

--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -1,0 +1,36 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import sqlite3
+import pytest
+import server
+
+
+def test_membership_foreign_key_enforced(tmp_path):
+    db_path = tmp_path / "test.db"
+    server.DB_FILENAME = str(db_path)
+    server.init_db()
+
+    conn = server.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users (username, salt, password_hash) VALUES (?, ?, ?)",
+        ("owner", b"s", b"h"),
+    )
+    owner_id = cur.lastrowid
+    cur.execute(
+        "INSERT INTO groups (name, invitation_code, owner_id) VALUES (?, ?, ?)",
+        ("g", "code", owner_id),
+    )
+    group_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+
+    conn = server.get_db_connection()
+    cur = conn.cursor()
+    with pytest.raises(sqlite3.IntegrityError):
+        cur.execute(
+            "INSERT INTO memberships (user_id, group_id, role) VALUES (?, ?, ?)",
+            (999, group_id, "member"),
+        )
+        conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- enforce SQLite foreign keys for all DB connections
- ensure default group and settings exist on first user registration
- add regression test asserting invalid membership insert raises IntegrityError

## Testing
- `pytest tests/test_foreign_keys.py -q`
- `pytest tests/test_api.py::test_register_and_login -q`
- `pytest tests/test_api.py::test_suggestions_crud -q`
- `pytest tests/test_settings.py::test_default_settings_creation -q`
- `pytest tests/test_group_members.py::test_group_members_add -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae1724aa088327a380418abac4de58