### PR TITLE
Add sheet music support for rehearsals

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -39,6 +39,14 @@ export async function syncRehearsalsCache() {
   state.rehearsalsCache = await api('/rehearsals');
 }
 
+export function uploadSheetMusic(id, instrument, dataUrl) {
+  return api(`/rehearsals/${id}`, 'PUT', { instrument, sheet: dataUrl });
+}
+
+export function deleteSheetMusic(id, instrument) {
+  return api(`/rehearsals/${id}/sheet?instrument=${encodeURIComponent(instrument)}`, 'DELETE');
+}
+
 setInterval(() => {
   if (state.currentUser) {
     syncRehearsalsCache().catch(() => {});

--- a/public/js/ui/index.js
+++ b/public/js/ui/index.js
@@ -15,7 +15,7 @@
   l’écran de connexion.
 */
 import { state, resetCaches } from "../state.js";
-import { api, syncRehearsalsCache } from "../api.js";
+import { api, syncRehearsalsCache, uploadSheetMusic, deleteSheetMusic } from "../api.js";
 import { checkSession, handleLogout, applyTheme, applyTemplate } from "../auth.js";
 
 
@@ -1144,6 +1144,70 @@ Object.defineProperties(state, {
       audioSection.appendChild(uploadBtn);
       audioSection.appendChild(fileInput);
       details.appendChild(audioSection);
+      // Partitions
+      const sheetSection = document.createElement('div');
+      sheetSection.style.marginTop = '8px';
+      const sheets = song.sheetMusic || {};
+      Object.keys(sheets).forEach((inst) => {
+        const wrap = document.createElement('div');
+        const link = document.createElement('a');
+        link.href = sheets[inst];
+        link.textContent = inst;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        wrap.appendChild(link);
+        const del = document.createElement('button');
+        del.className = 'btn-danger';
+        del.textContent = 'Supprimer';
+        del.style.marginLeft = '8px';
+        del.onclick = async (e) => {
+          e.preventDefault();
+          if (!confirm('Supprimer cette partition ?')) return;
+          try {
+            await deleteSheetMusic(song.id, inst);
+            renderRehearsals(container);
+          } catch (err) {
+            alert(err.message);
+          }
+        };
+        wrap.appendChild(del);
+        sheetSection.appendChild(wrap);
+      });
+      const instInput = document.createElement('input');
+      instInput.type = 'text';
+      instInput.placeholder = 'Instrument';
+      instInput.style.display = 'block';
+      instInput.style.marginTop = '8px';
+      const sheetInput = document.createElement('input');
+      sheetInput.type = 'file';
+      sheetInput.accept = '.pdf,image/*';
+      sheetInput.style.display = 'none';
+      const sheetBtn = document.createElement('button');
+      sheetBtn.className = 'btn-secondary';
+      sheetBtn.textContent = 'Ajouter une partition';
+      sheetBtn.onclick = (e) => {
+        e.preventDefault();
+        sheetInput.click();
+      };
+      sheetInput.onchange = async () => {
+        const file = sheetInput.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = async (ev) => {
+          const dataUrl = (ev.target?.result || '').toString();
+          try {
+            await uploadSheetMusic(song.id, instInput.value, dataUrl);
+            renderRehearsals(container);
+          } catch (err) {
+            alert(err.message);
+          }
+        };
+        reader.readAsDataURL(file);
+      };
+      sheetSection.appendChild(instInput);
+      sheetSection.appendChild(sheetBtn);
+      sheetSection.appendChild(sheetInput);
+      details.appendChild(sheetSection);
       // Afficher les notes et niveaux des autres membres
       // Filtrer les autres membres en ignorant la casse afin d’éviter de voir
       // apparaître plusieurs fois le même utilisateur (ex : « eric » et « Eric »).

--- a/tests/test_sheet_music.py
+++ b/tests/test_sheet_music.py
@@ -1,0 +1,75 @@
+import threading
+import http.client
+import time
+import json
+import server
+
+
+def start_test_server(tmp_db_path):
+    server.DB_FILENAME = str(tmp_db_path)
+    server.init_db()
+    httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    time.sleep(0.1)
+    return httpd, thread, port
+
+
+def stop_test_server(httpd, thread):
+    httpd.shutdown()
+    thread.join()
+
+
+def request(method, port, path, body=None, headers=None):
+    conn = http.client.HTTPConnection("127.0.0.1", port)
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers = {"Content-Type": "application/json", **(headers or {})}
+    conn.request(method, path, data, headers or {})
+    res = conn.getresponse()
+    res_body = res.read()
+    status = res.status
+    resp_headers = dict(res.getheaders())
+    conn.close()
+    return status, resp_headers, res_body
+
+
+def extract_cookie(headers):
+    cookie = headers.get("Set-Cookie")
+    if not cookie:
+        return None
+    return cookie.split(";", 1)[0]
+
+
+def test_sheet_music_upload_and_delete(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / "test.db")
+    try:
+        request("POST", port, "/api/register", {"username": "alice", "password": "pw"})
+        status, headers, _ = request("POST", port, "/api/login", {"username": "alice", "password": "pw"})
+        cookie = extract_cookie(headers)
+        headers = {"Cookie": cookie}
+
+        status, _, body = request("POST", port, "/api/1/rehearsals", {"title": "Song"}, headers)
+        assert status == 201
+        rid = json.loads(body)["id"]
+
+        pdf_data = "data:application/pdf;base64,AAA"
+        status, _, _ = request(
+            "PUT", port, f"/api/1/rehearsals/{rid}", {"instrument": "guitare", "sheet": pdf_data}, headers
+        )
+        assert status == 200
+
+        status, _, body = request("GET", port, "/api/1/rehearsals", headers=headers)
+        assert status == 200
+        songs = json.loads(body)
+        assert songs[0]["sheetMusic"]["guitare"] == pdf_data
+
+        status, _, _ = request("DELETE", port, f"/api/1/rehearsals/{rid}/sheet?instrument=guitare", headers=headers)
+        assert status == 200
+        status, _, body = request("GET", port, "/api/1/rehearsals", headers=headers)
+        songs = json.loads(body)
+        assert "guitare" not in songs[0]["sheetMusic"]
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- track sheet music per instrument via new `sheet_music_json` column and parser
- expose upload/delete sheet music APIs with client/UI helpers
- add regression tests for sheet music CRUD

## Testing
- `PYTHONPATH=. pytest tests/test_sheet_music.py`
- `PYTHONPATH=. pytest tests/test_audio_notes.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'playwright')*
- `pip install playwright` *(fails: Could not find a version that satisfies the requirement playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68af68888bf48327941125bb5a50b22a