### PR TITLE
Add partitions table and DAO

### DIFF
--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -34,3 +34,38 @@ def test_membership_foreign_key_enforced(tmp_path):
         )
         conn.commit()
     conn.close()
+
+
+def test_partition_cascade_on_rehearsal_delete(tmp_path):
+    db_path = tmp_path / "test.db"
+    server.DB_FILENAME = str(db_path)
+    server.init_db()
+
+    conn = server.get_db_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO users (username, salt, password_hash) VALUES (?, ?, ?)",
+        ("u", b"s", b"h"),
+    )
+    user_id = cur.lastrowid
+    cur.execute(
+        "INSERT INTO groups (name, invitation_code, owner_id) VALUES (?, ?, ?)",
+        ("g", "code", user_id),
+    )
+    group_id = cur.lastrowid
+    cur.execute(
+        "INSERT INTO rehearsals (title, creator_id, group_id) VALUES (?, ?, ?)",
+        ("song", user_id, group_id),
+    )
+    reh_id = cur.lastrowid
+    cur.execute(
+        "INSERT INTO partitions (rehearsal_id, path, display_name, uploader_id) VALUES (?, ?, ?, ?)",
+        (reh_id, "/tmp/file.pdf", "file.pdf", user_id),
+    )
+    conn.commit()
+    cur.execute("DELETE FROM rehearsals WHERE id = ?", (reh_id,))
+    conn.commit()
+    cur.execute("SELECT COUNT(*) FROM partitions WHERE rehearsal_id = ?", (reh_id,))
+    count = cur.fetchone()[0]
+    conn.close()
+    assert count == 0


### PR DESCRIPTION
## Summary
- add `partitions` table with cascade on rehearsals
- introduce `PartitionDAO` helper for partition CRUD
- migrate existing DBs to drop obsolete `sheet_music_json`

## Testing
- `pytest tests/test_foreign_keys.py`
- `pytest` *(fails: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68b0ac344ebc83279911dddf6b4cecd8