### PR TITLE
fix: resize profile avatar to fit header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,7 @@
         <button id="theme-toggle" aria-label="Changer le thème">🌙</button>
         <div id="menu-container">
             <button id="profile-btn" aria-label="Profil">
-                <img src="avatar.png" alt="Avatar">
+                <img src="avatar.png" alt="Avatar" width="40" height="40">
             </button>
             <div id="profile-menu" class="hidden flex flex-col">
                 <button id="menu-performances">Prestations</button>

--- a/public/style.css
+++ b/public/style.css
@@ -190,8 +190,8 @@ body, html {
 }
 
 #profile-btn {
-  width: 32px;
-  height: 32px;
+  width: 40px;
+  height: 40px;
   border: none;
   background: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- ensure profile avatar is constrained to 40x40 pixels
- match profile button size with avatar dimensions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68b41c7b2d908327bd8d0097ec0344a1