### PR TITLE
Simplify group name display in header

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,8 +22,7 @@
     <header class="header fixed top-0 w-full bg-pastel-50 transition-transform">
         <img src="logobt220.png" alt="BandTrack logo" class="logo-img">
         <div class="group-info">
-            <span>Groupe</span>
-            <span id="group-name"></span>
+            <span id="group-name" class="font-bold"></span>
             <span class="chevron">›</span>
         </div>
         <button id="theme-toggle" aria-label="Changer le thème">🌙</button>


### PR DESCRIPTION
## Summary
- Remove redundant "Groupe" label from header
- Bold group name in header for emphasis

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest` *(fails: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68b41f165764832793af6e5607a5063c