### PR TITLE
Refactor DB connection management

### DIFF
--- a/tests/test_agenda.py
+++ b/tests/test_agenda.py
@@ -16,18 +16,16 @@ def test_agenda_endpoint(tmp_path):
         headers = {"Cookie": cookie}
 
         # Insert rehearsal events directly into the database
-        conn = server.get_db_connection()
-        cur = conn.cursor()
-        cur.execute(
-            "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
-            ("2024-01-10T20:00", "Studio", 1, user_id),
-        )
-        cur.execute(
-            "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
-            ("2024-02-05T20:00", "Studio B", 1, user_id),
-        )
-        conn.commit()
-        conn.close()
+        with server.get_db_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
+                ("2024-01-10T20:00", "Studio", 1, user_id),
+            )
+            cur.execute(
+                "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
+                ("2024-02-05T20:00", "Studio B", 1, user_id),
+            )
 
         # Create performances via the API
         request(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,14 +79,12 @@ def test_login_without_group(tmp_path):
             {"username": "dave", "password": "pw"},
         )
         # Remove group memberships for this user
-        conn = server.get_db_connection()
-        cur = conn.cursor()
-        cur.execute(
-            "DELETE FROM memberships WHERE user_id = (SELECT id FROM users WHERE username = ?)",
-            ("dave",),
-        )
-        conn.commit()
-        conn.close()
+        with server.get_db_connection() as conn:
+            cur = conn.cursor()
+            cur.execute(
+                "DELETE FROM memberships WHERE user_id = (SELECT id FROM users WHERE username = ?)",
+                ("dave",),
+            )
         status, headers, body = request(
             "POST", port, "/api/login", {"username": "dave", "password": "pw"}
         )

--- a/tests/test_group_leave.py
+++ b/tests/test_group_leave.py
@@ -46,11 +46,10 @@ def test_group_member_can_leave_and_context_cleared(tmp_path):
         assert status == 403
 
         # last_group_id in database is cleared
-        conn = server.get_db_connection()
-        cur = conn.cursor()
-        cur.execute('SELECT last_group_id FROM users WHERE id = ?', (bob_user_id,))
-        row = cur.fetchone()
-        conn.close()
+        with server.get_db_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('SELECT last_group_id FROM users WHERE id = ?', (bob_user_id,))
+            row = cur.fetchone()
         assert row['last_group_id'] is None
     finally:
         stop_test_server(httpd, thread)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,11 +30,9 @@ def test_default_settings_creation(tmp_path):
         }
 
         # delete settings row and ensure GET recreates defaults
-        conn = server.get_db_connection()
-        cur = conn.cursor()
-        cur.execute('DELETE FROM settings WHERE group_id = ?', (group_id,))
-        conn.commit()
-        conn.close()
+        with server.get_db_connection() as conn:
+            cur = conn.cursor()
+            cur.execute('DELETE FROM settings WHERE group_id = ?', (group_id,))
 
         status, _, body = request('GET', port, f'/api/{group_id}/settings', headers=headers)
         assert status == 200


### PR DESCRIPTION
## Summary
- refactor get_db_connection into a context manager that commits and closes automatically
- update server code and tests to open database connections with `with` blocks

## Testing
- `pytest` *(fails: TypeError, KeyError and HTTP 500 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68b48b2485fc8327a6642d7ba54ca1f6