### PR TITLE
feat: add push notification support

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -77,3 +77,30 @@ self.addEventListener('fetch', event => {
     })
   );
 });
+
+self.addEventListener('push', event => {
+  let data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = { body: event.data.text() };
+  }
+  const title = data.title || 'BandTrack';
+  const options = {
+    body: data.body || '',
+    icon: '/logobt220.png'
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  event.waitUntil(
+    clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clientList => {
+      if (clientList.length > 0) {
+        return clientList[0].focus();
+      }
+      return clients.openWindow('/');
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add service worker push event handling and notification display
- store browser push subscriptions and expose POST /api/push-subscribe
- notify subscribers when new suggestions or rehearsals are created

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b49fecb1e08327b2c7007270589106