### PR TITLE
feat: migrate backend to postgres

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: '3.8'
 
 services:
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=bandtrack
+      - POSTGRES_PASSWORD=bandtrack
+      - POSTGRES_DB=bandtrack
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+
   bandtrack:
     build: .
     container_name: bandtrack
@@ -14,4 +24,13 @@ services:
       - SSL_KEY=/certs/key.pem
       - SSL_CERT=/certs/cert.pem
       - ORIGIN=https://localhost:8080
+      - DB_HOST=db
+      - DB_USER=bandtrack
+      - DB_PASSWORD=bandtrack
+      - DB_NAME=bandtrack
+    depends_on:
+      - db
     restart: unless-stopped
+
+volumes:
+  pgdata:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 reportlab
 websockets
+psycopg2-binary
+testcontainers

--- a/scripts/init_postgres.py
+++ b/scripts/init_postgres.py
@@ -1,0 +1,9 @@
+"""Initialize PostgreSQL schema for BandtrackPlus."""
+import server
+
+
+def main():
+    server.init_db()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -1,0 +1,62 @@
+"""Migrate data from an existing SQLite database to PostgreSQL.
+
+Usage:
+    python scripts/migrate_sqlite_to_postgres.py path/to/sqlite.db
+
+Environment variables for the PostgreSQL destination are the same as
+those used by ``server.py`` (``DATABASE_URL`` or ``DB_*`` variables).
+"""
+import argparse
+import sqlite3
+import server
+
+TABLES = [
+    "users",
+    "users_webauthn",
+    "groups",
+    "memberships",
+    "sessions",
+    "suggestions",
+    "suggestion_votes",
+    "rehearsals",
+    "partitions",
+    "performances",
+    "rehearsal_events",
+    "settings",
+    "logs",
+    "notifications",
+    "push_subscriptions",
+]
+
+
+def migrate(sqlite_path: str) -> None:
+    server.init_db()
+    with sqlite3.connect(sqlite_path) as src, server.get_db_connection() as dst:
+        src.row_factory = sqlite3.Row
+        cur_src = src.cursor()
+        cur_dst = dst.cursor()
+        for table in TABLES:
+            rows = cur_src.execute(f"SELECT * FROM {table}").fetchall()
+            if not rows:
+                continue
+            columns = rows[0].keys()
+            col_list = ",".join(columns)
+            placeholders = ",".join(["%s"] * len(columns))
+            for row in rows:
+                values = [row[c] for c in columns]
+                cur_dst.execute(
+                    f"INSERT INTO {table} ({col_list}) VALUES ({placeholders})",
+                    values,
+                )
+        dst.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate SQLite data to PostgreSQL")
+    parser.add_argument("sqlite_db", help="Path to the existing SQLite database")
+    args = parser.parse_args()
+    migrate(args.sqlite_db)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import os
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+try:
+    pg = PostgresContainer("postgres:15")
+    pg.start()
+    os.environ["DATABASE_URL"] = pg.get_connection_url()
+    import server
+    server.init_db()
+    _docker_ready = True
+except Exception:  # pragma: no cover - handled during testing
+    pg = None
+    server = None  # type: ignore
+    _docker_ready = False
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _stop_container():
+    if pg is not None:
+        yield
+        pg.stop()
+    else:
+        yield
+
+
+@pytest.fixture(autouse=True)
+def reset_db():
+    if not _docker_ready:
+        pytest.skip("PostgreSQL container not available")
+    with server.get_db_connection() as conn:  # type: ignore[union-attr]
+        cur = conn.cursor()
+        cur.execute("DROP SCHEMA public CASCADE")
+        cur.execute("CREATE SCHEMA public")
+        conn.commit()
+    server.init_db()  # type: ignore[union-attr]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,8 +7,7 @@ import time
 import server
 
 
-def start_test_server(tmp_db_path):
-    server.DB_FILENAME = str(tmp_db_path)
+def start_test_server(tmp_db_path=None):
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]

--- a/tests/test_audio_notes.py
+++ b/tests/test_audio_notes.py
@@ -8,8 +8,7 @@ import time
 import server
 
 
-def start_test_server(tmp_db_path):
-    server.DB_FILENAME = str(tmp_db_path)
+def start_test_server(tmp_db_path=None):
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]

--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -1,13 +1,11 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import sqlite3
+import psycopg2
 import pytest
 import server
 
 
 def test_membership_foreign_key_enforced(tmp_path):
-    db_path = tmp_path / "test.db"
-    server.DB_FILENAME = str(db_path)
     server.init_db()
 
     with server.get_db_connection() as conn:
@@ -25,7 +23,7 @@ def test_membership_foreign_key_enforced(tmp_path):
 
     with server.get_db_connection() as conn:
         cur = conn.cursor()
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises(psycopg2.IntegrityError):
             cur.execute(
                 "INSERT INTO memberships (user_id, group_id, role) VALUES (?, ?, ?)",
                 (999, group_id, "member"),
@@ -33,8 +31,6 @@ def test_membership_foreign_key_enforced(tmp_path):
 
 
 def test_partition_cascade_on_rehearsal_delete(tmp_path):
-    db_path = tmp_path / "test.db"
-    server.DB_FILENAME = str(db_path)
     server.init_db()
 
     with server.get_db_connection() as conn:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -7,8 +7,7 @@ import json
 import server
 
 
-def start_test_server(tmp_db_path):
-    server.DB_FILENAME = str(tmp_db_path)
+def start_test_server(tmp_db_path=None):
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]

--- a/tests/test_partitions.py
+++ b/tests/test_partitions.py
@@ -7,8 +7,7 @@ import json
 import server
 
 
-def start_test_server(tmp_db_path):
-    server.DB_FILENAME = str(tmp_db_path)
+def start_test_server(tmp_db_path=None):
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]


### PR DESCRIPTION
## Summary
- add PostgreSQL connection support and helpers in `server.py`
- provide migration scripts for initializing and populating a Postgres database
- update docker-compose with Postgres service and env vars
- switch test suite to Postgres using an ephemeral container fixture

## Testing
- `pip install -r requirements.txt`
- `pip install playwright`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b850f6bd0c83279075061b332e45d3