### PR TITLE
Handle missing psycopg2 for PostgreSQL mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ python3 server.py --port 8080
 
 Le serveur crée la base SQLite `bandtrack.db` au premier lancement.
 
+Pour activer le mode PostgreSQL (`DATABASE_URL` ou variables `DB_*`),
+installez aussi la bibliothèque `psycopg2` :
+
+```bash
+pip install psycopg2-binary
+```
+
 ## Tests
 
 Les tests automatisés ciblent uniquement la version Python et peuvent être exécutés dans le conteneur :


### PR DESCRIPTION
## Summary
- Gracefully handle optional `psycopg2` import and raise a clear error when PostgreSQL is configured but the library is absent
- Mention `psycopg2` requirement in the README for PostgreSQL mode

## Testing
- `playwright install chromium` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `pytest` *(fails: Download failed: server returned code 403 body 'Domain forbidden')*
- `pytest -k "not test_ui"`


------
https://chatgpt.com/codex/tasks/task_e_68b8599b5cc0832785e8a2cbfdae0532