### PR TITLE
Refactor SQL param handling for Postgres

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ reportlab
 websockets
 psycopg2-binary
 testcontainers
+sqlparse

--- a/tests/test_agenda.py
+++ b/tests/test_agenda.py
@@ -18,11 +18,13 @@ def test_agenda_endpoint(tmp_path):
         # Insert rehearsal events directly into the database
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            cur.execute(
+            server.execute_write(
+                cur,
                 "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
                 ("2024-01-10T20:00", "Studio", 1, user_id),
             )
-            cur.execute(
+            server.execute_write(
+                cur,
                 "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
                 ("2024-02-05T20:00", "Studio B", 1, user_id),
             )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,7 +80,8 @@ def test_login_without_group(tmp_path):
         # Remove group memberships for this user
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            cur.execute(
+            server.execute_write(
+                cur,
                 "DELETE FROM memberships WHERE user_id = (SELECT id FROM users WHERE username = ?)",
                 ("dave",),
             )

--- a/tests/test_group_leave.py
+++ b/tests/test_group_leave.py
@@ -48,7 +48,7 @@ def test_group_member_can_leave_and_context_cleared(tmp_path):
         # last_group_id in database is cleared
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            cur.execute('SELECT last_group_id FROM users WHERE id = ?', (bob_user_id,))
+            server.execute_write(cur, 'SELECT last_group_id FROM users WHERE id = ?', (bob_user_id,))
             row = cur.fetchone()
         assert row['last_group_id'] is None
     finally:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -32,7 +32,7 @@ def test_default_settings_creation(tmp_path):
         # delete settings row and ensure GET recreates defaults
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            cur.execute('DELETE FROM settings WHERE group_id = ?', (group_id,))
+            server.execute_write(cur, 'DELETE FROM settings WHERE group_id = ?', (group_id,))
 
         status, _, body = request('GET', port, f'/api/{group_id}/settings', headers=headers)
         assert status == 200


### PR DESCRIPTION
## Summary
- add `to_psycopg2_params` helper using `sqlparse` to safely map `?` placeholders
- use helper inside `execute_write` for PostgreSQL
- update tests to run queries via `execute_write`

## Testing
- `pytest` *(fails: all tests skipped due to missing PostgreSQL container / playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68b86a0a9ecc8327beb7108162717285