### PR TITLE
Add session group context test

### DIFF
--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,25 @@
+import json
+from test_api import start_test_server, stop_test_server, request, extract_cookie
+import bandtrack.api as server
+
+
+def test_session_group_context(tmp_path):
+    httpd, thread, port = start_test_server(tmp_path / "test.db")
+    try:
+        request("POST", port, "/api/register", {"username": "jane", "password": "pw"})
+        status, headers, _ = request("POST", port, "/api/login", {"username": "jane", "password": "pw"})
+        assert status == 200
+        cookie = extract_cookie(headers)
+        token = cookie.split("=", 1)[1]
+        with server.get_db_connection() as conn:
+            cur = conn.cursor()
+            server.execute_write(cur, "SELECT group_id FROM sessions WHERE token = ?", (token,))
+            row = cur.fetchone()
+            assert row is not None
+            assert row["group_id"] == 1
+        headers = {"Cookie": cookie}
+        status, _, body = request("GET", port, "/api/context", headers=headers)
+        assert status == 200
+        assert json.loads(body)["id"] == 1
+    finally:
+        stop_test_server(httpd, thread)


### PR DESCRIPTION
## Summary
- add regression test ensuring session records store active group and API context uses it

## Testing
- `pytest tests/test_sessions.py -q` *(fails: PostgreSQL container not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b87528505483279357117d1f5284ff