### PR TITLE
Use main.py as Docker entrypoint and copy package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the Python server, migration scripts and front‑end assets. The
+# Copy the Python server, migration scripts and front-end assets. The
 # SQLite database will be created at runtime.
-COPY server.py ./
+COPY main.py ./
+COPY bandtrack ./bandtrack
 COPY public ./public
 COPY scripts ./scripts
 
@@ -32,5 +33,5 @@ EXPOSE ${PORT}
 # Entrypoint to run the Python server.  We omit explicit host/port arguments
 # here because environment variables are not expanded when using the JSON
 # form of CMD.  The server reads HOST and PORT from its environment via
-# argparse defaults, so running ``python server.py`` is sufficient.
-CMD ["python", "server.py"]
+# argparse defaults, so running ``python main.py`` is sufficient.
+CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
- Update Dockerfile to copy `main.py` and the `bandtrack` package
- Run container with `main.py` as entrypoint

## Testing
- `python -m pytest` *(fails: No module named 'playwright')*
- `docker build -t bandtrackplus_test .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68b87df2d984832793568e8630af6b00