### PR TITLE
Replace server.py references with main.py

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ Elle repose sur une architecture simple et portable, conçue pour tourner dans u
 
 ### 3.2 Backend
 - **Serveur :** Python (`http.server`)
-- **Fichier principal :** `server.py`
+- **Fichier principal :** `main.py`
 - **Rôle :**
   - Gérer les endpoints REST
   - Authentification & sessions via cookies

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker compose up --build
 
 Les variables d'environnement peuvent aussi être définies dans `docker-compose.yml`.
 
-Lors du démarrage du conteneur, `server.py` exécute automatiquement les
+Lors du démarrage du conteneur, `main.py` exécute automatiquement les
 scripts de migration Python présents dans le dossier `scripts/`
 (`migrate_to_multigroup.py`, `migrate_performance_location.py`,
 `migrate_suggestion_votes.py`). Ils assurent la compatibilité des anciennes
@@ -67,7 +67,7 @@ Installer les dépendances (``reportlab`` pour l'export PDF) puis démarrer le s
 
 ```bash
 pip install -r requirements.txt
-python3 server.py --port 8080
+python3 main.py --port 8080
 ```
 
 Le serveur crée la base SQLite `bandtrack.db` au premier lancement.

--- a/bandtrack/api/__init__.py
+++ b/bandtrack/api/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-bandtrack-server/server.py
-==========================
+bandtrack.api
+=============
 
 This module implements a simple HTTP server in pure Python to provide a
 centralised backend for the BandTrack application.  It serves both the
@@ -35,10 +35,10 @@ Key features
 Usage
 -----
 
-Running the server is as simple as executing this file with Python:
+Running the server is as simple as executing ``main.py`` with Python:
 
 ```
-python3 server.py
+python3 main.py
 ```
 
 The server listens on port 8080 by default.  You can override the port
@@ -46,7 +46,7 @@ by setting the ``PORT`` environment variable or passing ``--port`` on
 the command line.  Example:
 
 ```
-python3 server.py --port 5000
+python3 main.py --port 5000
 ```
 
 The server automatically creates the database and tables on first run,

--- a/reset-db.sh
+++ b/reset-db.sh
@@ -3,9 +3,15 @@ set -euo pipefail
 
 rm -f bandtrack.db
 python3 - <<'PY'
-import server
-server.migrate_to_multigroup()
-server.init_db()
-server.migrate_performance_location()
-server.migrate_suggestion_votes()
+from scripts.migrate_to_multigroup import migrate as migrate_to_multigroup
+from bandtrack.db import init_db
+from scripts.migrate_performance_location import migrate as migrate_performance_location
+from scripts.migrate_suggestion_votes import migrate as migrate_suggestion_votes
+from scripts.migrate_sessions_group_id import migrate as migrate_sessions_group_id
+
+migrate_to_multigroup()
+init_db()
+migrate_performance_location()
+migrate_suggestion_votes()
+migrate_sessions_group_id()
 PY

--- a/scripts/init_postgres.py
+++ b/scripts/init_postgres.py
@@ -1,9 +1,9 @@
 """Initialize PostgreSQL schema for BandtrackPlus."""
-import server
+from bandtrack.db import init_db
 
 
 def main():
-    server.init_db()
+    init_db()
 
 if __name__ == "__main__":
     main()

--- a/scripts/migrate_sessions_group_id.py
+++ b/scripts/migrate_sessions_group_id.py
@@ -1,19 +1,19 @@
-import server
+from bandtrack.db import _using_postgres, get_db_connection, execute_write
 
 
 def migrate() -> bool:
-    if not server._using_postgres():
+    if not _using_postgres():
         return False
-    with server.get_db_connection() as conn:
+    with get_db_connection() as conn:
         cur = conn.cursor()
-        server.execute_write(
+        execute_write(
             cur,
             "SELECT column_name FROM information_schema.columns WHERE table_name='sessions' AND column_name='group_id'",
         )
         if cur.fetchone():
             return False
-        server.execute_write(cur, 'ALTER TABLE sessions ADD COLUMN group_id INTEGER')
-        server.execute_write(cur, 'UPDATE sessions SET group_id = NULL WHERE group_id IS NULL')
+        execute_write(cur, 'ALTER TABLE sessions ADD COLUMN group_id INTEGER')
+        execute_write(cur, 'UPDATE sessions SET group_id = NULL WHERE group_id IS NULL')
     return True
 
 

--- a/scripts/migrate_sqlite_to_postgres.py
+++ b/scripts/migrate_sqlite_to_postgres.py
@@ -4,11 +4,11 @@ Usage:
     python scripts/migrate_sqlite_to_postgres.py path/to/sqlite.db
 
 Environment variables for the PostgreSQL destination are the same as
-those used by ``server.py`` (``DATABASE_URL`` or ``DB_*`` variables).
+those used by ``main.py`` (``DATABASE_URL`` or ``DB_*`` variables).
 """
 import argparse
 import sqlite3
-import server
+from bandtrack.db import init_db, get_db_connection
 
 TABLES = [
     "users",
@@ -30,8 +30,8 @@ TABLES = [
 
 
 def migrate(sqlite_path: str) -> None:
-    server.init_db()
-    with sqlite3.connect(sqlite_path) as src, server.get_db_connection() as dst:
+    init_db()
+    with sqlite3.connect(sqlite_path) as src, get_db_connection() as dst:
         src.row_factory = sqlite3.Row
         cur_src = src.cursor()
         cur_dst = dst.cursor()


### PR DESCRIPTION
## Summary
- point README and architecture docs to `main.py`
- align migration scripts and reset helpers with new entrypoint
- update API module docs for `main.py` run commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b889f808d88327a48bb8a2a67c3326