### PR TITLE
Add package metadata and development install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ installez aussi la bibliothèque `psycopg2` :
 pip install psycopg2-binary
 ```
 
+### Installation en mode développement
+
+Pour rendre le paquet `bandtrack` importable depuis n'importe quel
+répertoire, installez le projet en mode editable :
+
+```bash
+pip install -e .
+```
+
+Cette commande crée un lien symbolique vers le code source local. Si le
+projet n'est pas installé, ajoutez son chemin au `PYTHONPATH` :
+
+```bash
+export PYTHONPATH="$(pwd):$PYTHONPATH"
+```
+
 ## Tests
 
 Les tests automatisés ciblent uniquement la version Python et peuvent être exécutés dans le conteneur :

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "bandtrack"
+version = "0.1.0"
+description = "BandTrack application backend"
+authors = [{ name = "BandTrack Contributors" }]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "reportlab",
+    "websockets",
+    "psycopg2-binary",
+    "testcontainers",
+    "sqlparse",
+]
+
+[tool.setuptools]
+packages = ["bandtrack"]


### PR DESCRIPTION
## Summary
- add pyproject configuration to package `bandtrack`
- document editable installs and PYTHONPATH in README for local development

## Testing
- `pip install -e .`
- `playwright install` *(fails: Domain forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b88b2e32088327a2174564fc2ef131