### PR TITLE
Allow migrations to target a custom database path

### DIFF
--- a/bandtrack/db/__init__.py
+++ b/bandtrack/db/__init__.py
@@ -358,6 +358,7 @@ def init_db():
     from scripts.migrate_performance_location import migrate as migrate_performance_location
     from scripts.migrate_sessions_group_id import migrate as migrate_sessions_group_id
 
+    # Run migrations that operate on a given database file
     migrate_to_multigroup(DB_FILENAME)
     migrate_suggestion_votes(DB_FILENAME)
     migrate_performance_location(DB_FILENAME)

--- a/scripts/migrate_performance_location.py
+++ b/scripts/migrate_performance_location.py
@@ -4,10 +4,10 @@ import sqlite3
 DB_PATH = os.path.join(os.path.dirname(__file__), '..', 'bandtrack.db')
 
 
-def migrate() -> bool:
+def migrate(db_path: str | None = None) -> bool:
     """Ensure the performances table has a location column.
     Returns True if a migration was performed."""
-    conn = sqlite3.connect(DB_PATH)
+    conn = sqlite3.connect(db_path or DB_PATH)
     conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
     cur.execute("PRAGMA table_info(performances)")

--- a/scripts/migrate_suggestion_votes.py
+++ b/scripts/migrate_suggestion_votes.py
@@ -4,8 +4,8 @@ import sqlite3
 DB_PATH = os.path.join(os.path.dirname(__file__), '..', 'bandtrack.db')
 
 
-def migrate() -> bool:
-    conn = sqlite3.connect(DB_PATH)
+def migrate(db_path: str | None = None) -> bool:
+    conn = sqlite3.connect(db_path or DB_PATH)
     conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
     # Ensure suggestion_votes table exists

--- a/scripts/migrate_to_multigroup.py
+++ b/scripts/migrate_to_multigroup.py
@@ -9,8 +9,8 @@ def generate_code() -> str:
     return base64.urlsafe_b64encode(os.urandom(4)).decode('ascii').rstrip('=')
 
 
-def migrate() -> bool:
-    conn = sqlite3.connect(DB_PATH)
+def migrate(db_path: str | None = None) -> bool:
+    conn = sqlite3.connect(db_path or DB_PATH)
     conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
     # If the core "users" table does not exist yet we are dealing with a

--- a/tests/test_migrations_scripts.py
+++ b/tests/test_migrations_scripts.py
@@ -1,0 +1,91 @@
+import os
+import sys
+import sqlite3
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+@pytest.fixture(autouse=True)
+def reset_db():  # type: ignore[override]
+    # Override the autouse reset_db fixture from conftest to avoid
+    # requiring a PostgreSQL container for these unit tests.
+    pass
+
+from scripts.migrate_to_multigroup import migrate as migrate_to_multigroup
+from scripts.migrate_suggestion_votes import migrate as migrate_suggestion_votes
+from scripts.migrate_performance_location import migrate as migrate_performance_location
+from scripts.migrate_sessions_group_id import migrate as migrate_sessions_group_id
+
+
+def test_migrate_to_multigroup_db_path(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE users (id INTEGER PRIMARY KEY, username TEXT)")
+    cur.execute("INSERT INTO users (username) VALUES ('alice')")
+    cur.execute(
+        "CREATE TABLE settings (id INTEGER PRIMARY KEY AUTOINCREMENT, group_id INTEGER, group_name TEXT, dark_mode INTEGER)"
+    )
+    conn.commit()
+    conn.close()
+    assert migrate_to_multigroup(str(db)) is True
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='groups'")
+    assert cur.fetchone() is not None
+    cur.execute("PRAGMA table_info(users)")
+    columns = [row[1] for row in cur.fetchall()]
+    assert 'role' in columns
+    conn.close()
+
+
+def test_migrate_suggestion_votes_db_path(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE users (id INTEGER PRIMARY KEY)")
+    cur.executemany("INSERT INTO users (id) VALUES (?)", [(1,), (2,)])
+    cur.execute("CREATE TABLE suggestions (id INTEGER PRIMARY KEY, likes INTEGER)")
+    cur.execute("INSERT INTO suggestions (id, likes) VALUES (1, 2)")
+    conn.commit()
+    conn.close()
+    assert migrate_suggestion_votes(str(db)) is True
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='suggestion_votes'")
+    assert cur.fetchone() is not None
+    cur.execute("SELECT COUNT(*) FROM suggestion_votes")
+    assert cur.fetchone()[0] == 2
+    conn.close()
+
+
+def test_migrate_performance_location_db_path(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE performances (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+    assert migrate_performance_location(str(db)) is True
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(performances)")
+    columns = [row[1] for row in cur.fetchall()]
+    assert 'location' in columns
+    conn.close()
+
+
+def test_migrate_sessions_group_id_db_path(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, token TEXT)")
+    conn.commit()
+    conn.close()
+    assert migrate_sessions_group_id(str(db)) is True
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(sessions)")
+    columns = [row[1] for row in cur.fetchall()]
+    assert 'group_id' in columns
+    conn.close()


### PR DESCRIPTION
## Summary
- add optional `db_path` argument to migration helpers and use it when provided
- invoke migration helpers with `DB_FILENAME`
- test migrations operate on supplied database path

## Testing
- `pytest tests/test_migrations_scripts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b89091f134832791fe31ac2dd0d82d