### PR TITLE
Handle missing users table in suggestion vote migration

### DIFF
--- a/scripts/migrate_suggestion_votes.py
+++ b/scripts/migrate_suggestion_votes.py
@@ -22,6 +22,11 @@ def migrate(db_path: str | None = None) -> bool:
     if cur.fetchone()[0] > 0:
         conn.close()
         return False
+    # Ensure users table exists before querying
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='users'")
+    if cur.fetchone() is None:
+        conn.close()
+        return False
     # Fetch all users
     cur.execute('SELECT id FROM users')
     users = [row[0] for row in cur.fetchall()]


### PR DESCRIPTION
## Summary
- Prevent suggestion vote migration from crashing when `users` table is absent by checking for table existence before querying

## Testing
- `pytest`
- `python scripts/migrate_suggestion_votes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8978f9aac8327a98f84bd3644a5e4