### PR TITLE
Handle missing performances table in migration

### DIFF
--- a/scripts/migrate_performance_location.py
+++ b/scripts/migrate_performance_location.py
@@ -10,6 +10,10 @@ def migrate(db_path: str | None = None) -> bool:
     conn = sqlite3.connect(db_path or DB_PATH)
     conn.execute('PRAGMA foreign_keys = ON')
     cur = conn.cursor()
+    cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='performances'")
+    if cur.fetchone() is None:
+        conn.close()
+        return False
     cur.execute("PRAGMA table_info(performances)")
     columns = [row[1] for row in cur.fetchall()]
     if 'location' not in columns:

--- a/tests/test_migrations_scripts.py
+++ b/tests/test_migrations_scripts.py
@@ -75,6 +75,16 @@ def test_migrate_performance_location_db_path(tmp_path):
     conn.close()
 
 
+def test_migrate_performance_location_missing_table(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("CREATE TABLE other (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+    assert migrate_performance_location(str(db)) is False
+
+
 def test_migrate_sessions_group_id_db_path(tmp_path):
     db = tmp_path / "test.db"
     conn = sqlite3.connect(db)


### PR DESCRIPTION
## Summary
- Safeguard performance location migration by checking for the performances table before altering schema
- Add unit test ensuring migration returns False when the performances table is missing

## Testing
- `pytest tests/test_migrations_scripts.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b89a0f0b1c8327a16cedd9d3e2816f