### PR TITLE
Add missing security-related imports

### DIFF
--- a/bandtrack/api/__init__.py
+++ b/bandtrack/api/__init__.py
@@ -75,6 +75,9 @@ import mimetypes
 import io
 import asyncio
 import threading
+import hmac
+import secrets
+import string
 from http import HTTPStatus
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 try:


### PR DESCRIPTION
## Summary
- Import `hmac`, `secrets`, and `string` in the API module to support future security features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89fb407c083279bd675d126e7a75e