### PR TITLE
Fix static root path for API server

### DIFF
--- a/bandtrack/api/__init__.py
+++ b/bandtrack/api/__init__.py
@@ -691,7 +691,13 @@ class BandTrackHandler(BaseHTTPRequestHandler):
                 return
             # Static public files.  Remove leading '/' and normalise path
             local_path = path.lstrip('/') or 'index.html'
-            static_root = os.path.join(os.path.dirname(__file__), 'public')
+            static_root = os.environ.get(
+                'STATIC_ROOT',
+                os.path.join(
+                    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+                    'public',
+                ),
+            )
             normalized = os.path.normpath(os.path.join(static_root, local_path))
             if not normalized.startswith(static_root):
                 self.send_error(HTTPStatus.FORBIDDEN)


### PR DESCRIPTION
## Summary
- ensure API server serves static files from repository `public` folder
- allow overriding static root via `STATIC_ROOT` environment variable

## Testing
- `pytest`
- `curl http://localhost:8080/`
- `docker build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a56357b08327a706deda17160951