### PR TITLE
Move testcontainers to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ export PYTHONPATH="$(pwd):$PYTHONPATH"
 
 ## Tests
 
-Les tests automatisés ciblent uniquement la version Python et peuvent être exécutés dans le conteneur :
+Les tests automatisés ciblent uniquement la version Python. Installez d'abord les dépendances de test via l'extra `dev` puis exécutez-les dans le conteneur :
 
 ```bash
+pip install .[dev]
 pytest
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,12 @@ dependencies = [
     "reportlab",
     "websockets",
     "psycopg2-binary",
-    "testcontainers",
     "sqlparse",
 ]
+
+[project.optional-dependencies]
+# Development and test dependencies
+dev = ["testcontainers"]
 
 [tool.setuptools]
 packages = ["bandtrack"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 reportlab
 websockets
 psycopg2-binary
-testcontainers
 sqlparse


### PR DESCRIPTION
## Summary
- remove `testcontainers` from runtime dependencies
- add optional `dev` extras with `testcontainers`
- document how to install test dependencies

## Testing
- `pip install .[dev]`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9f15c4bf083278c9d6a00e538317e