### PR TITLE
feat: allow custom websocket URL

### DIFF
--- a/public/js/ws.js
+++ b/public/js/ws.js
@@ -1,8 +1,14 @@
 import { state } from './state.js';
 
 const proto = location.protocol === 'https:' ? 'wss' : 'ws';
-const port = (location.port ? parseInt(location.port, 10) : (proto === 'wss' ? 443 : 80)) + 1;
-const ws = new WebSocket(`${proto}://${location.hostname}:${port}`);
+
+let wsUrl = window.WS_URL;
+if (!wsUrl) {
+  const basePort = location.port ? parseInt(location.port, 10) : (proto === 'wss' ? 443 : 80);
+  const port = window.WS_PORT ? parseInt(window.WS_PORT, 10) : basePort + 1;
+  wsUrl = `${proto}://${location.hostname}:${port}`;
+}
+const ws = new WebSocket(wsUrl);
 
 ws.onmessage = (event) => {
   try {


### PR DESCRIPTION
## Summary
- allow overriding WebSocket location using WS_URL or WS_PORT on client
- configure server to start WS server according to WS_URL/WS_PORT so HTTP and WS ports match

## Testing
- `pytest` (fails: Playwright browsers download blocked by 403)


------
https://chatgpt.com/codex/tasks/task_e_68b9f8c28ef88327a00643ad7eb2e19f