### PR TITLE
Allow cross-domain credentials in API fetch

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -3,7 +3,7 @@ import { state } from './state.js';
 export async function api(path, method = 'GET', data) {
   const options = {
     method,
-    credentials: 'same-origin',
+    credentials: 'include',
   };
   if (data !== undefined) {
     options.headers = { 'Content-Type': 'application/json' };
@@ -48,7 +48,7 @@ export async function uploadPartition(songId, file, displayName) {
   const res = await fetch(`/api/rehearsals/${songId}/partitions`, {
     method: 'POST',
     body: form,
-    credentials: 'same-origin',
+    credentials: 'include',
   });
   let json;
   try {


### PR DESCRIPTION
## Summary
- use `credentials: 'include'` for API requests and file uploads so cookies are sent on cross-domain deployments

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bb39d3e3d88327a3a84ae35e6b716c