### PR TITLE
feat: add websocket error handling and env config

### DIFF
--- a/public/js/ws.js
+++ b/public/js/ws.js
@@ -1,45 +1,62 @@
 import { state } from './state.js';
 
 const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+const env = typeof process !== 'undefined' ? process.env || {} : {};
 
-let wsUrl = window.WS_URL;
+let wsUrl = window.WS_URL || env.WS_URL;
 if (!wsUrl) {
   const basePort = location.port ? parseInt(location.port, 10) : (proto === 'wss' ? 443 : 80);
-  const port = window.WS_PORT ? parseInt(window.WS_PORT, 10) : basePort + 1;
+  const wsPort = window.WS_PORT || env.WS_PORT;
+  const port = wsPort ? parseInt(wsPort, 10) : basePort + 1;
   wsUrl = `${proto}://${location.hostname}:${port}`;
 }
-const ws = new WebSocket(wsUrl);
 
-ws.onmessage = (event) => {
-  try {
-    const data = JSON.parse(event.data);
-    if (data.groupId && state.activeGroupId && data.groupId !== state.activeGroupId) {
-      return;
+let ws;
+function connect() {
+  ws = new WebSocket(wsUrl);
+
+  ws.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      if (data.groupId && state.activeGroupId && data.groupId !== state.activeGroupId) {
+        return;
+      }
+      switch (data.type) {
+        case 'suggestion:new':
+          state.suggestionsCache = state.suggestionsCache || [];
+          state.suggestionsCache.push(data.suggestion);
+          break;
+        case 'suggestion:vote':
+          const idx = state.suggestionsCache?.findIndex(s => s.id === data.suggestion.id);
+          if (idx >= 0) {
+            state.suggestionsCache[idx] = data.suggestion;
+          }
+          break;
+        case 'rehearsal:new':
+          state.rehearsalsCache.push(data.rehearsal);
+          break;
+        case 'rehearsal:update':
+          const rIdx = state.rehearsalsCache.findIndex(r => r.id === data.rehearsal.id);
+          if (rIdx >= 0) {
+            state.rehearsalsCache[rIdx] = data.rehearsal;
+          }
+          break;
+        default:
+          break;
+      }
+    } catch (err) {
+      console.error('WS message error', err);
     }
-    switch (data.type) {
-      case 'suggestion:new':
-        state.suggestionsCache = state.suggestionsCache || [];
-        state.suggestionsCache.push(data.suggestion);
-        break;
-      case 'suggestion:vote':
-        const idx = state.suggestionsCache?.findIndex(s => s.id === data.suggestion.id);
-        if (idx >= 0) {
-          state.suggestionsCache[idx] = data.suggestion;
-        }
-        break;
-      case 'rehearsal:new':
-        state.rehearsalsCache.push(data.rehearsal);
-        break;
-      case 'rehearsal:update':
-        const rIdx = state.rehearsalsCache.findIndex(r => r.id === data.rehearsal.id);
-        if (rIdx >= 0) {
-          state.rehearsalsCache[rIdx] = data.rehearsal;
-        }
-        break;
-      default:
-        break;
-    }
-  } catch (err) {
-    console.error('WS message error', err);
-  }
-};
+  };
+
+  ws.onerror = (err) => {
+    console.error('WS connection error', err);
+  };
+
+  ws.onclose = (event) => {
+    console.warn('WS connection closed, retrying in 5s', event);
+    setTimeout(connect, 5000);
+  };
+}
+
+connect();


### PR DESCRIPTION
## Summary
- add ws.onerror and ws.onclose handlers with auto-reconnect
- support WS_URL and WS_PORT from env or build-time variables

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build:js`
- `pytest` *(fails: 24 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4b51faf8832798869429a5397893