### PR TITLE
test: switch to postgres fixture

### DIFF
--- a/tests/test_account_deletion.py
+++ b/tests/test_account_deletion.py
@@ -2,8 +2,8 @@ import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_account_deletion(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_account_deletion():
+    httpd, thread, port = start_test_server()
     try:
         # Register initial admin user to set up default group
         request('POST', port, '/api/register', {'username': 'admin', 'password': 'pw'})
@@ -25,8 +25,8 @@ def test_account_deletion(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_cannot_delete_account_while_owning_group(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_cannot_delete_account_while_owning_group():
+    httpd, thread, port = start_test_server()
     try:
         # Register initial admin user to set up default group
         request('POST', port, '/api/register', {'username': 'admin', 'password': 'pw'})

--- a/tests/test_agenda.py
+++ b/tests/test_agenda.py
@@ -4,8 +4,8 @@ from test_api import start_test_server, stop_test_server, request, extract_cooki
 import bandtrack.api as server
 
 
-def test_agenda_endpoint(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_agenda_endpoint():
+    httpd, thread, port = start_test_server()
     try:
         # Register and login to obtain session cookie
         status, headers, body = request(
@@ -20,12 +20,12 @@ def test_agenda_endpoint(tmp_path):
             cur = conn.cursor()
             server.execute_write(
                 cur,
-                "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
+                "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (%s, %s, %s, %s)",
                 ("2024-01-10T20:00", "Studio", 1, user_id),
             )
             server.execute_write(
                 cur,
-                "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (?, ?, ?, ?)",
+                "INSERT INTO rehearsal_events (date, location, group_id, creator_id) VALUES (%s, %s, %s, %s)",
                 ("2024-02-05T20:00", "Studio B", 1, user_id),
             )
 
@@ -78,8 +78,8 @@ def test_agenda_endpoint(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_agenda_crud(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_agenda_crud():
+    httpd, thread, port = start_test_server()
     try:
         request("POST", port, "/api/register", {"username": "bob", "password": "pw"})
         status, headers, _ = request(

--- a/tests/test_audio_notes.py
+++ b/tests/test_audio_notes.py
@@ -8,7 +8,7 @@ import time
 import bandtrack.api as server
 
 
-def start_test_server(tmp_db_path=None):
+def start_test_server():
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]
@@ -45,8 +45,8 @@ def extract_cookie(headers):
     return cookie.split(";", 1)[0]
 
 
-def test_multiple_audio_notes_with_titles(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_multiple_audio_notes_with_titles():
+    httpd, thread, port = start_test_server()
     try:
         request("POST", port, "/api/register", {"username": "alice", "password": "pw"})
         status, headers, _ = request("POST", port, "/api/login", {"username": "alice", "password": "pw"})

--- a/tests/test_context_persistence.py
+++ b/tests/test_context_persistence.py
@@ -2,8 +2,8 @@ import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_group_context_persists_across_login(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_context_persists_across_login():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})

--- a/tests/test_foreign_keys.py
+++ b/tests/test_foreign_keys.py
@@ -5,20 +5,20 @@ import pytest
 import bandtrack.api as server
 
 
-def test_membership_foreign_key_enforced(tmp_path):
+def test_membership_foreign_key_enforced():
     server.init_db()
 
     with server.get_db_connection() as conn:
         cur = conn.cursor()
         server.execute_write(
             cur,
-            "INSERT INTO users (username, salt, password_hash) VALUES (?, ?, ?)",
+            "INSERT INTO users (username, salt, password_hash) VALUES (%s, %s, %s)",
             ("owner", b"s", b"h"),
         )
         owner_id = cur.lastrowid
         server.execute_write(
             cur,
-            "INSERT INTO groups (name, invitation_code, owner_id) VALUES (?, ?, ?)",
+            "INSERT INTO groups (name, invitation_code, owner_id) VALUES (%s, %s, %s)",
             ("g", "code", owner_id),
         )
         group_id = cur.lastrowid
@@ -28,40 +28,40 @@ def test_membership_foreign_key_enforced(tmp_path):
         with pytest.raises(psycopg2.IntegrityError):
             server.execute_write(
                 cur,
-                "INSERT INTO memberships (user_id, group_id, role) VALUES (?, ?, ?)",
+                "INSERT INTO memberships (user_id, group_id, role) VALUES (%s, %s, %s)",
                 (999, group_id, "member"),
             )
 
 
-def test_partition_cascade_on_rehearsal_delete(tmp_path):
+def test_partition_cascade_on_rehearsal_delete():
     server.init_db()
 
     with server.get_db_connection() as conn:
         cur = conn.cursor()
         server.execute_write(
             cur,
-            "INSERT INTO users (username, salt, password_hash) VALUES (?, ?, ?)",
+            "INSERT INTO users (username, salt, password_hash) VALUES (%s, %s, %s)",
             ("u", b"s", b"h"),
         )
         user_id = cur.lastrowid
         server.execute_write(
             cur,
-            "INSERT INTO groups (name, invitation_code, owner_id) VALUES (?, ?, ?)",
+            "INSERT INTO groups (name, invitation_code, owner_id) VALUES (%s, %s, %s)",
             ("g", "code", user_id),
         )
         group_id = cur.lastrowid
         server.execute_write(
             cur,
-            "INSERT INTO rehearsals (title, creator_id, group_id) VALUES (?, ?, ?)",
+            "INSERT INTO rehearsals (title, creator_id, group_id) VALUES (%s, %s, %s)",
             ("song", user_id, group_id),
         )
         reh_id = cur.lastrowid
         server.execute_write(
             cur,
-            "INSERT INTO partitions (rehearsal_id, path, display_name, uploader_id) VALUES (?, ?, ?, ?)",
+            "INSERT INTO partitions (rehearsal_id, path, display_name, uploader_id) VALUES (%s, %s, %s, %s)",
             (reh_id, "/tmp/file.pdf", "file.pdf", user_id),
         )
-        server.execute_write(cur, "DELETE FROM rehearsals WHERE id = ?", (reh_id,))
-        server.execute_write(cur, "SELECT COUNT(*) FROM partitions WHERE rehearsal_id = ?", (reh_id,))
+        server.execute_write(cur, "DELETE FROM rehearsals WHERE id = %s", (reh_id,))
+        server.execute_write(cur, "SELECT COUNT(*) FROM partitions WHERE rehearsal_id = %s", (reh_id,))
         count = cur.fetchone()[0]
     assert count == 0

--- a/tests/test_group_invite.py
+++ b/tests/test_group_invite.py
@@ -2,8 +2,8 @@ import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_group_invite_new_user(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_invite_new_user():
+    httpd, thread, port = start_test_server()
     try:
         # Register admin user
         request('POST', port, '/api/register', {'username': 'admin@example.com', 'password': 'pw'})
@@ -26,8 +26,8 @@ def test_group_invite_new_user(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_group_invite_existing_user(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_invite_existing_user():
+    httpd, thread, port = start_test_server()
     try:
         # Register admin user
         request('POST', port, '/api/register', {'username': 'admin@example.com', 'password': 'pw'})

--- a/tests/test_group_isolation.py
+++ b/tests/test_group_isolation.py
@@ -2,8 +2,8 @@ import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_group_isolation_and_context(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_isolation_and_context():
+    httpd, thread, port = start_test_server()
     try:
         # Alice registers and logs in (admin of default group 1)
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})

--- a/tests/test_group_leave.py
+++ b/tests/test_group_leave.py
@@ -5,8 +5,8 @@ import bandtrack.api as server
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_group_member_can_leave_and_context_cleared(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_member_can_leave_and_context_cleared():
+    httpd, thread, port = start_test_server()
     try:
         # Register admin user and log in
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
@@ -48,7 +48,7 @@ def test_group_member_can_leave_and_context_cleared(tmp_path):
         # last_group_id in database is cleared
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            server.execute_write(cur, 'SELECT last_group_id FROM users WHERE id = ?', (bob_user_id,))
+            server.execute_write(cur, 'SELECT last_group_id FROM users WHERE id = %s', (bob_user_id,))
             row = cur.fetchone()
         assert row['last_group_id'] is None
     finally:

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -2,8 +2,8 @@ import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_group_flow(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_flow():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})

--- a/tests/test_memberships.py
+++ b/tests/test_memberships.py
@@ -2,8 +2,8 @@ import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_memberships_crud(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_memberships_crud():
+    httpd, thread, port = start_test_server()
     try:
         # Register admin user
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
@@ -48,8 +48,8 @@ def test_memberships_crud(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_memberships_add(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_memberships_add():
+    httpd, thread, port = start_test_server()
     try:
         # Register admin user
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
@@ -86,8 +86,8 @@ def test_memberships_add(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_memberships_cross_group_delete(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_memberships_cross_group_delete():
+    httpd, thread, port = start_test_server()
     try:
         # Register admin user and log in
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
@@ -124,8 +124,8 @@ def test_memberships_cross_group_delete(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_memberships_delete_requires_identifier(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_memberships_delete_requires_identifier():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -7,7 +7,7 @@ import json
 import bandtrack.api as server
 
 
-def start_test_server(tmp_db_path=None):
+def start_test_server():
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]
@@ -54,8 +54,8 @@ def make_pdf_body(boundary, pdf_bytes, filename="sample.pdf"):
     ).encode() + pdf_bytes + f"\r\n--{boundary}--\r\n".encode()
 
 
-def test_upload_notifications_and_opt_out(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_upload_notifications_and_opt_out():
+    httpd, thread, port = start_test_server()
     try:
         # Register two users
         status, headers, _ = request("POST", port, "/api/register", {"username": "alice", "password": "pw"})

--- a/tests/test_partitions.py
+++ b/tests/test_partitions.py
@@ -8,7 +8,7 @@ import logging
 import bandtrack.api as server
 
 
-def start_test_server(tmp_db_path=None):
+def start_test_server():
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]
@@ -55,8 +55,8 @@ def make_pdf_body(boundary, pdf_bytes, filename="sample.pdf"):
     ).encode() + pdf_bytes + f"\r\n--{boundary}--\r\n".encode()
 
 
-def test_partition_upload_list_download_and_delete(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_partition_upload_list_download_and_delete():
+    httpd, thread, port = start_test_server()
     try:
         status, headers, _ = request("POST", port, "/api/register", {"username": "alice", "password": "pw"})
         assert status == 200
@@ -116,8 +116,8 @@ def test_partition_upload_list_download_and_delete(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_partition_delete_missing_file_logs_warning(tmp_path, caplog):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_partition_delete_missing_file_logs_warning(caplog):
+    httpd, thread, port = start_test_server()
     try:
         status, headers, _ = request("POST", port, "/api/register", {"username": "alice", "password": "pw"})
         assert status == 200

--- a/tests/test_password_change.py
+++ b/tests/test_password_change.py
@@ -2,8 +2,8 @@ import json
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_password_change(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_password_change():
+    httpd, thread, port = start_test_server()
     try:
         # Register and login
         status, headers, _ = request(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -3,8 +3,8 @@ from test_api import start_test_server, stop_test_server, request, extract_cooki
 import bandtrack.api as server
 
 
-def test_session_group_context(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_session_group_context():
+    httpd, thread, port = start_test_server()
     try:
         request("POST", port, "/api/register", {"username": "jane", "password": "pw"})
         status, headers, _ = request("POST", port, "/api/login", {"username": "jane", "password": "pw"})
@@ -13,7 +13,7 @@ def test_session_group_context(tmp_path):
         token = cookie.split("=", 1)[1]
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            server.execute_write(cur, "SELECT group_id FROM sessions WHERE token = ?", (token,))
+            server.execute_write(cur, "SELECT group_id FROM sessions WHERE token = %s", (token,))
             row = cur.fetchone()
             assert row is not None
             assert row["group_id"] == 1

--- a/tests/test_sessions_group_id.py
+++ b/tests/test_sessions_group_id.py
@@ -7,7 +7,7 @@ import time
 import bandtrack.api as server
 
 
-def start_test_server(tmp_db_path=None):
+def start_test_server():
     server.init_db()
     httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), server.BandTrackHandler)
     port = httpd.server_address[1]
@@ -44,8 +44,8 @@ def extract_cookie(headers):
     return cookie.split(";", 1)[0]
 
 
-def test_session_contains_group_id(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / "test.db")
+def test_session_contains_group_id():
+    httpd, thread, port = start_test_server()
     try:
         request("POST", port, "/api/register", {"username": "sam", "password": "pw"})
         status, headers, _ = request("POST", port, "/api/login", {"username": "sam", "password": "pw"})
@@ -54,7 +54,7 @@ def test_session_contains_group_id(tmp_path):
         token = cookie.split("=", 1)[1]
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            server.execute_write(cur, 'SELECT group_id FROM sessions WHERE token = ?', (token,))
+            server.execute_write(cur, 'SELECT group_id FROM sessions WHERE token = %s', (token,))
             row = cur.fetchone()
             assert row is not None
             assert row['group_id'] == 1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,8 +5,8 @@ import bandtrack.api as server
 from test_api import start_test_server, stop_test_server, request, extract_cookie
 
 
-def test_default_settings_creation(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_default_settings_creation():
+    httpd, thread, port = start_test_server()
     try:
         # register and login
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
@@ -32,7 +32,7 @@ def test_default_settings_creation(tmp_path):
         # delete settings row and ensure GET recreates defaults
         with server.get_db_connection() as conn:
             cur = conn.cursor()
-            server.execute_write(cur, 'DELETE FROM settings WHERE group_id = ?', (group_id,))
+            server.execute_write(cur, 'DELETE FROM settings WHERE group_id = %s', (group_id,))
 
         status, _, body = request('GET', port, f'/api/{group_id}/settings', headers=headers)
         assert status == 200
@@ -43,8 +43,8 @@ def test_default_settings_creation(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_settings_update(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_settings_update():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
@@ -77,8 +77,8 @@ def test_settings_update(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_group_rename(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_rename():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})
@@ -102,8 +102,8 @@ def test_group_rename(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_group_rename_unauthorized(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_group_rename_unauthorized():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})

--- a/tests/test_ui_account_deletion.py
+++ b/tests/test_ui_account_deletion.py
@@ -1,9 +1,12 @@
+import pytest
 from test_api import start_test_server, stop_test_server, request, extract_cookie
+
+pytest.importorskip("playwright")
 from playwright.sync_api import sync_playwright
 
 
-def test_ui_account_deletion(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_ui_account_deletion():
+    httpd, thread, port = start_test_server()
     try:
         # Register and login to create session
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
@@ -42,8 +45,8 @@ def test_ui_account_deletion(tmp_path):
         stop_test_server(httpd, thread)
 
 
-def test_ui_account_deletion_from_group_setup(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_ui_account_deletion_from_group_setup():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'bob', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'bob', 'password': 'pw'})

--- a/tests/test_ui_delete_account_button_visible.py
+++ b/tests/test_ui_delete_account_button_visible.py
@@ -1,9 +1,12 @@
+import pytest
 from test_api import start_test_server, stop_test_server, request, extract_cookie
+
+pytest.importorskip("playwright")
 from playwright.sync_api import sync_playwright
 
 
-def test_delete_account_button_visible(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_delete_account_button_visible():
+    httpd, thread, port = start_test_server()
     try:
         # register and login to obtain session cookie
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})

--- a/tests/test_ui_group_rename.py
+++ b/tests/test_ui_group_rename.py
@@ -1,9 +1,12 @@
+import pytest
 from test_api import start_test_server, stop_test_server, request, extract_cookie
+
+pytest.importorskip("playwright")
 from playwright.sync_api import sync_playwright
 
 
-def test_dropdown_updates_after_group_rename(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_dropdown_updates_after_group_rename():
+    httpd, thread, port = start_test_server()
     try:
         # Register, login and create a group via API
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})

--- a/tests/test_ui_xss.py
+++ b/tests/test_ui_xss.py
@@ -5,8 +5,8 @@ pytest.importorskip("playwright")
 from playwright.sync_api import sync_playwright
 
 
-def test_script_title_not_executed(tmp_path):
-    httpd, thread, port = start_test_server(tmp_path / 'test.db')
+def test_script_title_not_executed():
+    httpd, thread, port = start_test_server()
     try:
         request('POST', port, '/api/register', {'username': 'alice', 'password': 'pw'})
         status, headers, _ = request('POST', port, '/api/login', {'username': 'alice', 'password': 'pw'})


### PR DESCRIPTION
## Summary
- drop SQLite usage from tests and rely on Postgres testcontainer
- adjust tests to use psycopg2 placeholders and errors
- ensure Playwright-based tests skip when dependency is missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc7079ad8c8327b97474a946ae03f7